### PR TITLE
Fixed warnings reported by GoReportCard

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ go:
   - 1.4
   - 1.4.2
   - 1.5
+  - 1.6
+  - 1.7
 before_install:
   - go get github.com/axw/gocov/gocov
   - go get github.com/mattn/goveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: go
 go:
-  - 1.4
-  - 1.4.2
-  - 1.5
-  - 1.6
   - 1.7
 before_install:
   - go get github.com/axw/gocov/gocov

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 sg allows one to gauge response times of an HTTP service under stress.
 
 [![Build Status](https://travis-ci.org/ChristopherRabotin/sg.svg?branch=master)](https://travis-ci.org/ChristopherRabotin/sg) [![Coverage Status](https://coveralls.io/repos/ChristopherRabotin/sg/badge.svg?branch=master&service=github)](https://coveralls.io/github/ChristopherRabotin/sg?branch=master)
+[![goreport](https://goreportcard.com/badge/github.com/ChristopherRabotin/sg)](https://goreportcard.com/report/github.com/ChristopherRabotin/sg)
 
 # Features
 *Note:* what is in italics is not yet implemented.

--- a/profile_test.go
+++ b/profile_test.go
@@ -3,8 +3,6 @@ package main
 import (
 	"encoding/xml"
 	"fmt"
-	"github.com/franela/goreq"
-	. "github.com/smartystreets/goconvey/convey"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -12,6 +10,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/franela/goreq"
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestURL(t *testing.T) {
@@ -207,9 +208,9 @@ func TestTokenized(t *testing.T) {
 	Convey("Tokenizing data from a request works as expected", t, func() {
 		// Let's setup a test server.
 		var ts *httptest.Server
-		var requestHeaders http.Header
+		//var requestHeaders http.Header
 		ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			requestHeaders = r.Header
+			//requestHeaders = r.Header
 			if r.Method == "GET" && r.URL.Path == "/test" {
 				defer r.Body.Close()
 				w.Header().Add("X-Custom-Hdr", "Custom Header")

--- a/profile_test.go
+++ b/profile_test.go
@@ -208,9 +208,7 @@ func TestTokenized(t *testing.T) {
 	Convey("Tokenizing data from a request works as expected", t, func() {
 		// Let's setup a test server.
 		var ts *httptest.Server
-		//var requestHeaders http.Header
 		ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			//requestHeaders = r.Header
 			if r.Method == "GET" && r.URL.Path == "/test" {
 				defer r.Body.Close()
 				w.Header().Add("X-Custom-Hdr", "Custom Header")

--- a/qurbine.go
+++ b/qurbine.go
@@ -27,7 +27,7 @@ type Request struct {
 	Data        *Tokenized     `xml:"data"`                  // Data to send.
 	Result      *Result        `xml:"result"`
 	ongoingReqs chan struct{}  // Channel of ongoing requests.
-	doneChan    chan *Response // Channel of responses to buffer them prior to transfering them to doneReqs.
+	doneChan    chan *Response // Channel of responses to buffer them prior to transferring them to doneReqs.
 	doneReqs    []*Response    // List of responses.
 	doneWg      sync.WaitGroup // Wait group of the completed requests.
 }

--- a/qurbine.go
+++ b/qurbine.go
@@ -3,12 +3,13 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/franela/goreq"
 	"net/http"
 	"runtime"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/franela/goreq"
 )
 
 // Request stores the request as XML.
@@ -110,7 +111,6 @@ func (r *Request) Spawn(parent *Response, wg *sync.WaitGroup) {
 			startTime := time.Now()
 			gresp, err := greq.Do()
 			resp.FromGoResp(gresp, err, startTime)
-			gresp = nil
 			if err != nil {
 				log.Critical("could not send request to #%d %s: %s", no, r.URL, err)
 			}
@@ -235,6 +235,7 @@ type Response struct {
 	duration      time.Duration
 }
 
+// FromGoResp initializes the Response from a goreq.Response.
 func (resp *Response) FromGoResp(gresp *goreq.Response, err error, startTime time.Time) {
 	if err == nil {
 		gresp.Body.FromJsonTo(&resp.JSON)

--- a/sg_test.go
+++ b/sg_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	. "github.com/smartystreets/goconvey/convey"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -12,6 +11,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 type GETTestJSON struct {
@@ -51,8 +52,8 @@ func TestStressGauge(t *testing.T) {
 						if cookie.Value != "42" {
 							returnFailure("cookie value not 42", w, t)
 						}
-						marsh, err := json.Marshal(GETTestJSON{URL: r.URL.String()})
-						serveErrorOrBytes(w, err, marsh, t)
+						marsh, merr := json.Marshal(GETTestJSON{URL: r.URL.String()})
+						serveErrorOrBytes(w, merr, marsh, t)
 					} else {
 						returnFailure(fmt.Sprintf("cookie error: %s", err), w, t)
 					}
@@ -123,7 +124,7 @@ func TestStressGauge(t *testing.T) {
 								<url base="%s-not-uri/error/" />
 							</request>
 						</test>
-					</sg>`, ts.URL, ts.URL, ts.URL, ts.URL, ts.URL, ts.URL)
+					</sg>`, ts.URL, ts.URL, ts.URL, ts.URL, ts.URL, ts.URL, ts.URL)
 		profile := Profile{}
 		err := xml.Unmarshal([]byte(profileData), &profile)
 		if err != nil {

--- a/stats.go
+++ b/stats.go
@@ -99,7 +99,7 @@ func (p *Percentages) Swap(i, j int) {
 // Percentage returns the items in position X.
 func (p *Percentages) Percentage(v int) *Duration {
 	if v < 0 || v > 100 {
-		panic(fmt.Errorf("incorrect value requested %f", v))
+		panic(fmt.Errorf("incorrect value requested %d", v))
 	}
 	if v == 0 {
 		return p.vals[0]

--- a/stats_test.go
+++ b/stats_test.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"encoding/xml"
-	. "github.com/smartystreets/goconvey/convey"
 	"testing"
 	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestPercentages(t *testing.T) {
@@ -35,7 +36,7 @@ func TestPercentages(t *testing.T) {
 				So(p.vals[i].State, ShouldEqual, "critical")
 			}
 			b, _ := xml.Marshal(p)
-			So(string(b), ShouldEqual, `<Percentages><mean duration="49.5µs" state="nominal"></mean><shortest duration="0" state="nominal"></shortest><p10 duration="10µs" state="nominal"></p10><p25 duration="25µs" state="nominal"></p25><p50 duration="50µs" state="warning"></p50><p66 duration="66µs" state="warning"></p66><p75 duration="75µs" state="critical"></p75><p80 duration="80µs" state="critical"></p80><p90 duration="90µs" state="critical"></p90><p95 duration="95µs" state="critical"></p95><p98 duration="98µs" state="critical"></p98><p99 duration="99µs" state="critical"></p99><longest duration="99µs" state="critical"></longest></Percentages>`)
+			So(string(b), ShouldEqual, `<Percentages><mean duration="49.5µs" state="nominal"></mean><shortest duration="0s" state="nominal"></shortest><p10 duration="10µs" state="nominal"></p10><p25 duration="25µs" state="nominal"></p25><p50 duration="50µs" state="warning"></p50><p66 duration="66µs" state="warning"></p66><p75 duration="75µs" state="critical"></p75><p80 duration="80µs" state="critical"></p80><p90 duration="90µs" state="critical"></p90><p95 duration="95µs" state="critical"></p95><p98 duration="98µs" state="critical"></p98><p99 duration="99µs" state="critical"></p99><longest duration="99µs" state="critical"></longest></Percentages>`)
 			So(func() { p.Percentage(-1) }, ShouldPanic)
 		})
 	})


### PR DESCRIPTION
Also removed support for go < 1.7. Note that this is a standalone program, so one can compile it against go 1.7 and run it. Also note that the only reason why go <1.7 support was removed is because of the change to Duration.String which adds the "s" for second when parsing a zero time duration.
